### PR TITLE
Add the markdown tables extension

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -77,6 +77,7 @@ MARKITUP_FILTER = ('markdown.markdown', {
         'outline',
         'attr_list',
         'attr_cols',
+        'markdown.extensions.tables',
     ],
 })
 # Use HTTPS jquery URL so it's accessible on HTTPS pages (e.g. editing a talk)


### PR DESCRIPTION
Enable python-markdown's support for markdown tables, since it seems a generally useful thing to have available.
